### PR TITLE
add exception for epay-bri

### DIFF
--- a/lib/vt/validate_transaction.js
+++ b/lib/vt/validate_transaction.js
@@ -91,11 +91,11 @@ const validators = module.exports = {
     validateTransactionPayload(payload, requiredFields, callback) {
         const type = payload.payment_type;
 
-        if (!utils.hasProperty(payload, type)) {
+        if (!utils.hasProperty(payload, type) && type!=='bri_epay') {
             return callback(new Error(`Not a valid ${type} transaction payload`));
         }
 
-        if (!utils.hasProperty(payload[type], requiredFields)) {
+        if (!utils.hasProperty(payload[type], requiredFields) && type!=='bri_epay') {
             return callback(new Error(`${type} transaction requires ${requiredFields.toString()} fields`));
         }
 


### PR DESCRIPTION
Add exception for payment_type epay-bri when validating transaction payload so epay-bri could pass the validation. (epay-bri could not pass the validation because it is the only one that doesn't have/need property with it's own name)